### PR TITLE
feat: add NFS storage support with Synology integration

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
   - ./metrics-server/ks.yaml
+  - ./nfs-csi/ks.yaml
   - ./reloader/ks.yaml
   - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/nfs-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/app/helmrelease.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nfs-csi
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: csi-driver-nfs
+      version: v4.8.0
+      sourceRef:
+        kind: HelmRepository
+        name: csi-driver-nfs
+        namespace: flux-system
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    driver:
+      name: nfs.csi.k8s.io
+    controller:
+      replicas: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+    node:
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 128Mi

--- a/kubernetes/apps/kube-system/nfs-csi/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/app/kustomization.yaml
@@ -2,6 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kube-system
 resources:
-  - ./external-dns.yaml
-  - ./csi-driver-nfs.yaml
+  - ./helmrelease.yaml
+  - ./storageclass.yaml

--- a/kubernetes/apps/kube-system/nfs-csi/app/storageclass.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/app/storageclass.yaml
@@ -1,0 +1,51 @@
+---
+# Read-Write NFS Storage Class (for app data)
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-rw
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: "nas.home.x00.sh"
+  share: "/volume1/kubernetes"  # Dedicated share for app data
+mountOptions:
+  - nfsvers=3
+  - hard
+  - intr
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Read-Only Media Storage Class
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-media-ro
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: "nas.home.x00.sh"
+  share: "/volume1/media"
+mountOptions:
+  - nfsvers=3
+  - hard
+  - intr
+  - ro
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+# Read-Write Media Storage Class (for media management apps)
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: nfs-media-rw
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: "nas.home.x00.sh"
+  share: "/volume1/media"
+mountOptions:
+  - nfsvers=3
+  - hard
+  - intr
+reclaimPolicy: Retain
+volumeBindingMode: Immediate

--- a/kubernetes/apps/kube-system/nfs-csi/ks.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app nfs-csi
+  namespace: flux-system
+spec:
+  targetNamespace: kube-system
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/kube-system/nfs-csi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-ops
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/flux/meta/repos/csi-driver-nfs.yaml
+++ b/kubernetes/flux/meta/repos/csi-driver-nfs.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: csi-driver-nfs
+  namespace: flux-system
+spec:
+  interval: 1h
+  url: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts


### PR DESCRIPTION
## Summary
- Add comprehensive NFS storage infrastructure with dynamic provisioning
- Integrate with Synology NAS at `nas.home.x00.sh`
- Configure multiple storage classes for different use cases
- Install NFS CSI driver for Kubernetes-native storage management

## Storage Classes Added
1. **`nfs-rw`** (default): Application data on `/volume1/kubernetes`
2. **`nfs-media-ro`**: Read-only access to `/volume1/media` 
3. **`nfs-media-rw`**: Read-write access to `/volume1/media`

## Features
- **Dynamic Provisioning**: Automatic PVC creation and management
- **Multi-Purpose**: Separate storage classes for apps vs media
- **Synology Integration**: Optimized for Synology NAS with NFSv3
- **Flexible Access**: Read-only and read-write patterns for media
- **GitOps Ready**: Full Flux integration with Helm charts

## Prerequisites
- Create `/volume1/kubernetes` folder on Synology NAS
- Configure NFS permissions for cluster network `10.0.0.0/24`
- Enable NFS service in Synology DSM

## Test Plan
- [x] Validate Kubernetes manifests and Helm configurations
- [x] Verify CSI driver installation manifests
- [x] Confirm storage class configurations
- [ ] Deploy and verify NFS CSI driver starts successfully
- [ ] Test PVC provisioning with each storage class
- [ ] Validate NFS mounts work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)