### PR TITLE
fix: correct GitRepository reference in Home Assistant kustomization

### DIFF
--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -14,7 +14,8 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-ops
+    name: flux-system
+    namespace: flux-system
   wait: false
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Summary
- Fix Home Assistant deployment issue caused by incorrect GitRepository reference
- Change sourceRef from "home-ops" to "flux-system" to match existing pattern
- Add missing namespace field for GitRepository reference

## Problem
Home Assistant kustomization was failing with error:
```
GitRepository.source.toolkit.fluxcd.io "home-ops" not found
```

## Solution
Updated the sourceRef in `/kubernetes/apps/default/home-assistant/ks.yaml` to:
- Use correct GitRepository name: `flux-system`
- Include namespace: `flux-system` 
- Match the pattern used by other applications (echo)

## Impact
- Fixes Home Assistant deployment stuck in NotReady state
- Allows Home Assistant to reconcile and deploy successfully
- No changes to functionality, only corrects configuration

## Test Plan
- [x] Validate YAML syntax and structure
- [x] Confirm sourceRef matches working applications
- [ ] Verify Home Assistant kustomization becomes Ready after merge
- [ ] Test Home Assistant pod deployment and startup

🤖 Generated with [Claude Code](https://claude.ai/code)