### PR TITLE
fix: correct GitRepository reference in NFS CSI kustomization

### DIFF
--- a/kubernetes/apps/kube-system/nfs-csi/ks.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/ks.yaml
@@ -14,7 +14,8 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: home-ops
+    name: flux-system
+    namespace: flux-system
   wait: false
   interval: 30m
   retryInterval: 1m


### PR DESCRIPTION
## Summary
- Fix NFS CSI driver deployment issue caused by incorrect GitRepository reference
- Change sourceRef from "home-ops" to "flux-system" to match existing pattern
- Add missing namespace field for GitRepository reference

## Problem
NFS CSI kustomization was failing with error:
```
GitRepository.source.toolkit.fluxcd.io "home-ops" not found
```

This prevented:
- NFS CSI driver deployment
- Storage class creation
- Any persistent volume provisioning

## Solution
Updated the sourceRef in `/kubernetes/apps/kube-system/nfs-csi/ks.yaml` to:
- Use correct GitRepository name: `flux-system`
- Include namespace: `flux-system`
- Match the pattern used by other applications

## Impact
- Enables NFS CSI driver deployment to kube-system namespace
- Creates storage classes: nfs-rw, nfs-media-ro, nfs-media-rw
- Allows persistent volume provisioning for applications
- Unblocks Home Assistant deployment (waiting for storage)

## Test Plan
- [x] Validate YAML syntax and structure
- [x] Confirm sourceRef matches working applications
- [ ] Verify NFS CSI kustomization becomes Ready after merge
- [ ] Test NFS CSI driver pods start successfully
- [ ] Validate storage classes are created
- [ ] Test PVC provisioning with Synology NAS

🤖 Generated with [Claude Code](https://claude.ai/code)