### PR TITLE
fix: add secret substitution to Home Assistant kustomization

### DIFF
--- a/kubernetes/apps/default/home-assistant/ks.yaml
+++ b/kubernetes/apps/default/home-assistant/ks.yaml
@@ -10,13 +10,21 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
   path: ./kubernetes/apps/default/home-assistant/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
+  retryInterval: 1m
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
   wait: false
   interval: 30m
-  retryInterval: 1m
   timeout: 5m


### PR DESCRIPTION
## Summary
- Add missing SOPS decryption and secret substitution configuration to Home Assistant
- Fix HTTPRoute hostname validation error preventing deployment
- Enable proper ${SECRET_DOMAIN} variable substitution

## Problem
Home Assistant HelmRelease was failing with error:
```
HTTPRoute.gateway.networking.k8s.io "home-assistant" is invalid: 
spec.hostnames[0]: Invalid value: "home-assistant.${SECRET_DOMAIN}": 
spec.hostnames[0] in body should match hostname validation pattern
```

**Root Cause**: Missing secret substitution configuration meant `${SECRET_DOMAIN}` wasn't being resolved from cluster-secrets.

## Solution
Added missing configuration to `/kubernetes/apps/default/home-assistant/ks.yaml`:
- **SOPS decryption**: Enable encrypted secret access
- **postBuild.substituteFrom**: Enable variable substitution from cluster-secrets
- **Pattern matching**: Follow same configuration as working echo application

## Impact
- ✅ Resolves HTTPRoute hostname validation error
- ✅ Enables proper domain substitution (home-assistant.x00.sh)
- ✅ Allows Home Assistant to deploy successfully
- ✅ Enables external access via Cloudflare tunnel

## Test Plan
- [x] Validate YAML syntax and structure
- [x] Confirm configuration matches working echo app pattern
- [ ] Verify Home Assistant HelmRelease becomes Ready after merge
- [ ] Test Home Assistant pod deployment and startup
- [ ] Validate external access at home-assistant.x00.sh
- [ ] Test persistent storage with NFS CSI driver

🤖 Generated with [Claude Code](https://claude.ai/code)