### PR TITLE
fix: add nolock mount option to NFS storage classes

### DIFF
--- a/kubernetes/apps/kube-system/nfs-csi/app/storageclass.yaml
+++ b/kubernetes/apps/kube-system/nfs-csi/app/storageclass.yaml
@@ -14,6 +14,7 @@ mountOptions:
   - nfsvers=3
   - hard
   - intr
+  - nolock
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
 ---
@@ -30,6 +31,7 @@ mountOptions:
   - nfsvers=3
   - hard
   - intr
+  - nolock
   - ro
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
@@ -47,5 +49,6 @@ mountOptions:
   - nfsvers=3
   - hard
   - intr
+  - nolock
 reclaimPolicy: Retain
 volumeBindingMode: Immediate


### PR DESCRIPTION
## Summary
- Add `nolock` mount option to all NFS storage classes
- Fix NFS volume provisioning failures preventing Home Assistant deployment
- Resolve rpc.statd dependency issue on cluster nodes

## Problem
Home Assistant PVC provisioning was failing with error:
```
mount.nfs: rpc.statd is not running but is required for remote locking.
mount.nfs: Either use '-o nolock' to keep locks local, or start statd.
```

**Root Cause**: NFS mount attempts require file locking, but rpc.statd service is not running on cluster nodes.

## Solution
Added `nolock` mount option to all storage classes:
- **nfs-rw**: For application data
- **nfs-media-ro**: For read-only media access  
- **nfs-media-rw**: For read-write media access

This option disables remote file locking and uses local locking instead, which is appropriate for most container workloads.

## Impact
- ✅ Enables successful NFS volume provisioning
- ✅ Allows Home Assistant PVC to be created
- ✅ Unblocks Home Assistant pod deployment
- ✅ Maintains security with local file locking

## Test Plan
- [x] Validate storage class YAML syntax
- [x] Confirm nolock option is standard NFS practice for containers
- [ ] Verify PVC provisioning succeeds after merge
- [ ] Test Home Assistant pod starts successfully
- [ ] Validate NFS mount works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)