### PR TITLE
fix: update Home Assistant image tag to stable version

### DIFF
--- a/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/default/home-assistant/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
           app:
             image:
               repository: ghcr.io/home-assistant/home-assistant
-              tag: 2025.7.3
+              tag: 2025.1.6
             env:
               TZ: UTC
             probes:


### PR DESCRIPTION
## Summary
- Fix Home Assistant container image tag from non-existent version to stable release
- Change from `2025.7.3` to `2025.1.6` to resolve ImagePullBackOff errors
- Use pinned version for reproducible deployments

## Problem
Home Assistant pod was failing to start with error:
```
Failed to pull image "ghcr.io/home-assistant/home-assistant:2025.7.3": 
ghcr.io/home-assistant/home-assistant:2025.7.3: not found
```

**Root Cause**: Version `2025.7.3` doesn't exist in the container registry.

## Solution
- Updated to stable version `2025.1.6` which is confirmed to exist
- Maintains pinned version approach (no `latest` tags)
- Ensures reproducible deployments across environments

## Impact
- ✅ Resolves ImagePullBackOff preventing Home Assistant startup
- ✅ Enables Home Assistant pod to start successfully
- ✅ Maintains deployment stability with pinned versions
- ✅ Allows full Home Assistant deployment completion

## Test Plan
- [x] Validate image tag exists in container registry
- [x] Confirm version follows semantic versioning
- [ ] Verify Home Assistant pod starts successfully after merge
- [ ] Test Home Assistant application functionality
- [ ] Validate external access via home-assistant.x00.sh

🤖 Generated with [Claude Code](https://claude.ai/code)